### PR TITLE
update cca e-open house and fix the wrong links under For Teachers. 

### DIFF
--- a/_caps-connection/For Teachers.md
+++ b/_caps-connection/For Teachers.md
@@ -46,13 +46,13 @@ description: ""
 | -------- | -------- | -------- |
 |||
 
-<a href="https://scmobile.moe.edu.sg/login"><img src="/images/MIMS.png" 
+<a href="https://idp.mims.moe.gov.sg/nidp/saml2/sso"><img src="/images/MIMS.png" 
      style="width:33%;float:left"></a>
 		 
-<a href="https://rbs.avero-tech.com/"><img src="/images/iExams.png" 
+<a href="https://iexams.seab.gov.sg/login"><img src="/images/iExams.png" 
      style="width:33%;float:left"></a>
 		 
-<a href="https://ssoe2.moe.edu.sg/"><img src="/images/INTRANET.png" 
+<a href="https://intranet.moe.gov.sg/"><img src="/images/INTRANET.png" 
      style="width:33%;float:left"></a>
 		 
 | **MIMS Portal**	 |**iExams**|**MOE Intranet** |
@@ -65,9 +65,6 @@ description: ""
 <a href="https://go.gov.sg/#/"><img src="/images/gov%20shortener.png" 
      style="width:33%;float:left"></a>
 		 
-<a href="https://imtl.moe.edu.sg/cos/o.x?c=/ca7_imtl/user&func=login"><img src="/images/iMTL.png" 
-     style="width:33%;float:left"></a>
-		 
-| **MIMS Portal**	 |**iExams**|**MOE Intranet** |
+| **FormSG**	 |**GO Link Shortner**| |
 | -------- | -------- | -------- |
 |||

--- a/pages/Announcements.md
+++ b/pages/Announcements.md
@@ -37,5 +37,4 @@ Click on the title to find out more about Home-based Learning.
 
 **[CCA E-Open House](https://sites.google.com/view/caps-cca-openhouse)**
 
-Click on the title to view CCA e-open house. 
-
+Click on the title to view CCA e-open house.

--- a/pages/Announcements.md
+++ b/pages/Announcements.md
@@ -3,8 +3,6 @@ title: Announcements
 permalink: /announcements/
 description: ""
 ---
-
-
 **[Parents and Students Resource Kits](https://tinyurl.com/capshblresourcekit)**
 
 Click on the title to view more information on how to manage Home-based Learning.
@@ -35,3 +33,9 @@ Click on the title to view more National Library Board resources.
 **[Home-based Learning](https://tinyurl.com/classhblcaps)**
 
 Click on the title to find out more about Home-based Learning.
+
+
+**[CCA E-Open House](https://sites.google.com/view/caps-cca-openhouse)**
+
+Click on the title to view CCA e-open house. 
+


### PR DESCRIPTION
update cca e-open house and fix the wrong links under For Teachers. 